### PR TITLE
Update `federation_tester.py`

### DIFF
--- a/bot/wikidata/federation_tester.py
+++ b/bot/wikidata/federation_tester.py
@@ -2,12 +2,13 @@
 # -*- coding: utf-8 -*-
 """
 Check if all the links at:
-* https://raw.githubusercontent.com/wikimedia/wikidata-query-deploy/master/whitelist.txt
+* https://gerrit.wikimedia.org/r/plugins/gitiles/operations/puppet/+/refs/heads/production/modules/query_service/templates/allowlist.txt.epp
 * https://www.mediawiki.org/wiki/Wikidata_Query_Service/User_Manual/SPARQL_Federation_endpoints
 all work using a simple query and report the results at:
 https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/Federation_report
 
 """
+import base64
 import pywikibot
 import pywikibot.data.sparql
 import requests
@@ -21,22 +22,26 @@ class FederationBot:
         """
 
         """
-        self.site =  pywikibot.Site(u'mediawiki', u'mediawiki')
+        self.site =  pywikibot.Site('mediawiki', 'mediawiki')
         self.repo = self.site.data_repository()
         self.gitlist = self.getGitList()
         self.wikilist = self.getWikiList()
 
     def getGitList(self):
         result = []
-        page = requests.get(u'https://raw.githubusercontent.com/wikimedia/wikidata-query-deploy/master/whitelist.txt')
-        for line in page.text.splitlines():
-            result.append(line)
+        allowlist_base64 = requests.get('https://gerrit.wikimedia.org/r/plugins/gitiles/operations/puppet/+/refs/heads/production/modules/query_service/templates/allowlist.txt.epp?format=TEXT').text
+        allowlist_epp = base64.b64decode(allowlist_base64).decode('utf8')
+        for line in allowlist_epp.splitlines():
+            # note: the allowlist is in puppet syntax, not quite plain text
+            if line.startswith('http') and '<' not in line and '>' not in line:
+                # this looks like a real URL line, hope for the best and just add it
+                result.append(line)
         return result
 
     def getWikiList(self):
         result = []
-        page = pywikibot.Page(self.site, title=u'Wikidata Query Service/User Manual/SPARQL Federation endpoints')
-        regex = u'\s*\|-\s*\n\s*\|\s*(http.+)'
+        page = pywikibot.Page(self.site, title='Wikidata Query Service/User Manual/SPARQL Federation endpoints')
+        regex = r'\s*\|-\s*\n\s*\|\s*(http.+)'
         matches = re.finditer(regex, page.text)
         for match in matches:
             result.append(match.group(1))
@@ -46,35 +51,35 @@ class FederationBot:
         """
         Starts the robot.
         """
-        reportpage = pywikibot.Page(self.repo, title=u'Wikidata:SPARQL query service/Federation report')
-        newtext = u'Testing the different SPARQL endpoints. Taking the links from '
-        newtext += u'[https://raw.githubusercontent.com/wikimedia/wikidata-query-deploy/master/whitelist.txt git] and '
-        newtext += u'[[:mw:Wikidata Query Service/User Manual/SPARQL Federation endpoints|the manual]] and doing a '
-        newtext += u'[https://query.wikidata.org/#SELECT%20%3Fa%20%3Fb%20%3Fc%20WHERE%20%7B%20%0A%20%20SERVICE%20%3Chttp%3A%2F%2Fdata.bibliotheken.nl%2Fsparql%3E%20%7B%0A%20%20%20%20SELECT%20%3Fa%20%3Fb%20%3Fc%20WHERE%20%7B%20%3Fa%20%3Fb%20%3Fc%20%7D%20LIMIT%201%0A%20%20%7D%0A%7D%20LIMIT%201 very simple federated query]\n\n'
-        newtext += u'{| class="wikitable sortable"\n! Link !! Git !! Wiki !! Query works?\n'
+        reportpage = pywikibot.Page(self.repo, title='Wikidata:SPARQL query service/Federation report')
+        newtext = 'Testing the different SPARQL endpoints. Taking the links from '
+        newtext += '[https://gerrit.wikimedia.org/r/plugins/gitiles/operations/puppet/+/refs/heads/production/modules/query_service/templates/allowlist.txt.epp git] and '
+        newtext += '[[:mw:Wikidata Query Service/User Manual/SPARQL Federation endpoints|the manual]] and doing a '
+        newtext += '[https://query.wikidata.org/#SELECT%20%3Fa%20%3Fb%20%3Fc%20WHERE%20%7B%20%0A%20%20SERVICE%20%3Chttp%3A%2F%2Fdata.bibliotheken.nl%2Fsparql%3E%20%7B%0A%20%20%20%20SELECT%20%3Fa%20%3Fb%20%3Fc%20WHERE%20%7B%20%3Fa%20%3Fb%20%3Fc%20%7D%20LIMIT%201%0A%20%20%7D%0A%7D%20LIMIT%201 very simple federated query] ([https://github.com/multichill/toollabs/blob/master/bot/wikidata/federation_tester.py bot source code]).\n\n'
+        newtext += '{| class="wikitable sortable"\n! Link !! Git !! Wiki !! Query works?\n'
         alllist = sorted(set(self.gitlist) | set(self.wikilist))
         for link in alllist:
-            newtext += u'|-\n'
-            newtext += u'| %s\n' % (link,)
+            newtext += '|-\n'
+            newtext += '| %s\n' % (link,)
             if link in self.gitlist:
-                newtext += u'| OK\n' # FIXME: Add pretty icon
+                newtext += '| OK\n' # FIXME: Add pretty icon
             else:
-                newtext += u'| Missing\n'
+                newtext += '| Missing\n'
             if link in self.wikilist:
-                newtext += u'| OK\n' # FIXME: Add pretty icon
+                newtext += '| OK\n' # FIXME: Add pretty icon
             else:
-                newtext += u'| Missing\n'
+                newtext += '| Missing\n'
             queryworks = self.testSparql(link)
             if queryworks:
-                newtext += u'| OK\n' # FIXME: Add pretty icon
+                newtext += '| OK\n' # FIXME: Add pretty icon
             else:
-                newtext += u'| Query failed\n'
-        newtext += u'|}\n[[Category:Wikidata:SPARQL query service]]'
-        print newtext
-        reportpage.put(newtext, summary=u'Updating federation report')
+                newtext += '| Query failed\n'
+        newtext += '|}\n[[Category:Wikidata:SPARQL query service]]'
+        print(newtext)
+        reportpage.put(newtext, summary='Updating federation report')
 
     def testSparql(self, link):
-        query = u"""SELECT ?a ?b ?c WHERE { 
+        query = """SELECT ?a ?b ?c WHERE { 
   SERVICE <%s> {
     SELECT ?a ?b ?c WHERE { ?a ?b ?c } LIMIT 1
   }
@@ -84,11 +89,8 @@ class FederationBot:
             queryresult = sq.select(query)
             if queryresult:
                 return True
-            print queryresult
-            #for resultitem in queryresult:
-            #    qid = resultitem.get('item').replace(u'http://www.wikidata.org/entity/', u'')
-            #    result[resultitem.get('id')] = qid
-        except pywikibot.exceptions.TimeoutError:
+            print(queryresult)
+        except (pywikibot.exceptions.TimeoutError, pywikibot.exceptions.ServerError):
             return False
         return False
 


### PR DESCRIPTION
During the [Federated Queries Documentation Brunch][1], we noticed that this page had not been updated in a while. This commit tries to update the federation tester so it can be run regularly again.

Changes include:
* porting the code from Python 2 to Python 3 (lol)
* removing a bit of long-dead commented out code
* updating the location of the allowlist file
* catching an additional exception type, because the British Museum endpoint seems to just time out and apparently WDQS doesn’t handle that well (I confirmed that the previous exception type is also still raised for some other endpoints and thus remains necessary)
* adding a link to the bot’s source code to the header, for the next person who wants to fix it

[1]: https://de.wikipedia.org/wiki/Wikipedia:WikiMUC/Federated_Queries_Documentation_Brunch

----

I tested this by commenting out the `reportpage.put()` line; I assume the actual edit to the page should still work if pywikibot is configured correctly (which I didn’t want to bother with).